### PR TITLE
Added daemonization capability using supervisord

### DIFF
--- a/etc/init.d/supervisor_debian.init
+++ b/etc/init.d/supervisor_debian.init
@@ -1,0 +1,167 @@
+#! /bin/sh
+#
+# skeleton	example file to build /etc/init.d/ scripts.
+#		This file should be used to construct scripts for /etc/init.d.
+#
+#		Written by Miquel van Smoorenburg <miquels@cistron.nl>.
+#		Modified for Debian
+#		by Ian Murdock <imurdock@gnu.ai.mit.edu>.
+#               Further changes by Javier Fernandez-Sanguino <jfs@debian.org>
+#
+# Version:	@(#)skeleton  1.9  26-Feb-2001  miquels@cistron.nl
+#
+### BEGIN INIT INFO
+# Provides:          supervisor
+# Required-Start:    $remote_fs $network $named
+# Required-Stop:     $remote_fs $network $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start/stop supervisor
+# Description:       Start/stop supervisor daemon and its configured
+#                    subprocesses.
+### END INIT INFO
+
+. /lib/lsb/init-functions
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/bin/supervisord
+NAME=supervisord
+DESC=supervisor
+
+test -x $DAEMON || exit 0
+
+LOGDIR=/var/log/supervisor
+PIDFILE=/var/run/$NAME.pid
+DODTIME=5                   # Time to wait for the server to die, in seconds
+                            # If this value is set too low you might not
+                            # let some servers to die gracefully and
+                            # 'restart' will not work
+
+# Include supervisor defaults if available
+if [ -f /etc/default/supervisor ] ; then
+	. /etc/default/supervisor
+fi
+DAEMON_OPTS="-c /etc/supervisor/supervisord.conf $DAEMON_OPTS"
+
+set -e
+
+running_pid()
+{
+    # Check if a given process pid's cmdline matches a given name
+    pid=$1
+    name=$2
+    [ -z "$pid" ] && return 1
+    [ ! -d /proc/$pid ] &&  return 1
+    (cat /proc/$pid/cmdline | tr "\000" "\n"|grep -q $name) || return 1
+    return 0
+}
+
+running()
+{
+# Check if the process is running looking at /proc
+# (works for all users)
+
+    # No pidfile, probably no daemon present
+    [ ! -f "$PIDFILE" ] && return 1
+    # Obtain the pid and check it against the binary name
+    pid=`cat $PIDFILE`
+    running_pid $pid $DAEMON || return 1
+    return 0
+}
+
+force_stop() {
+# Forcefully kill the process
+    [ ! -f "$PIDFILE" ] && return
+    if running ; then
+        kill -15 $pid
+        # Is it really dead?
+        [ -n "$DODTIME" ] && sleep "$DODTIME"s
+        if running ; then
+            kill -9 $pid
+            [ -n "$DODTIME" ] && sleep "$DODTIME"s
+            if running ; then
+                echo "Cannot kill $NAME (pid=$pid)!"
+                exit 1
+            fi
+        fi
+    fi
+    rm -f $PIDFILE
+    return 0
+}
+
+case "$1" in
+  start)
+	echo -n "Starting $DESC: "
+	start-stop-daemon --start --quiet --pidfile $PIDFILE \
+		--startas $DAEMON -- $DAEMON_OPTS
+	test -f $PIDFILE || sleep 1
+        if running ; then
+            echo "$NAME."
+        else
+            echo " ERROR."
+        fi
+	;;
+  stop)
+	echo -n "Stopping $DESC: "
+	start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE 
+	echo "$NAME."
+	;;
+  force-stop)
+	echo -n "Forcefully stopping $DESC: "
+        force_stop
+        if ! running ; then
+            echo "$NAME."
+        else
+            echo " ERROR."
+        fi
+	;;
+  #reload)
+	#
+	#	If the daemon can reload its config files on the fly
+	#	for example by sending it SIGHUP, do it here.
+	#
+	#	If the daemon responds to changes in its config file
+	#	directly anyway, make this a do-nothing entry.
+	#
+	# echo "Reloading $DESC configuration files."
+	# start-stop-daemon --stop --signal 1 --quiet --pidfile \
+	#	/var/run/$NAME.pid --exec $DAEMON
+  #;;
+  force-reload)
+	#
+	#	If the "reload" option is implemented, move the "force-reload"
+	#	option to the "reload" entry above. If not, "force-reload" is
+	#	just the same as "restart" except that it does nothing if the
+	#   daemon isn't already running.
+	# check wether $DAEMON is running. If so, restart
+	start-stop-daemon --stop --test --quiet --pidfile $PIDFILE \
+        --startas $DAEMON \
+	&& $0 restart \
+	|| exit 0
+	;;
+  restart)
+    echo -n "Restarting $DESC: "
+    start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
+	[ -n "$DODTIME" ] && sleep $DODTIME
+	start-stop-daemon --start --quiet --pidfile $PIDFILE \
+		--startas $DAEMON -- $DAEMON_OPTS
+	echo "$NAME."
+	;;
+  status)
+    echo -n "$NAME is "
+    if running ;  then
+        echo "running"
+    else
+        echo " not running."
+        exit 1
+    fi
+    ;;
+  *)
+	N=/etc/init.d/$NAME
+	# echo "Usage: $N {start|stop|restart|reload|force-reload}" >&2
+	echo "Usage: $N {start|stop|restart|force-reload|status|force-stop}" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/etc/init.d/supervisord_centos.init
+++ b/etc/init.d/supervisord_centos.init
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# supervisord   This scripts turns supervisord on
+#
+# Author:       Mike McGrath <mmcgrath@redhat.com> (based off yumupdatesd)
+#
+# chkconfig:	- 95 04
+#
+# description:  supervisor is a process control utility.  It has a web based
+#               xmlrpc interface as well as a few other nifty features.
+# processname:  supervisord
+# config: /etc/supervisord.conf
+# pidfile: /var/run/supervisord.pid
+#
+
+# source function library
+. /etc/rc.d/init.d/functions
+
+RETVAL=0
+
+start() {
+	echo -n $"Starting supervisord: "
+	daemon supervisord
+	RETVAL=$?
+	echo
+	[ $RETVAL -eq 0 ] && touch /var/lock/subsys/supervisord
+}
+
+stop() {
+	echo -n $"Stopping supervisord: "
+	killproc supervisord
+	echo
+	[ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/supervisord
+}
+
+restart() {
+	stop
+	start
+}
+
+case "$1" in
+  start)
+	start
+	;;
+  stop) 
+	stop
+	;;
+  restart|force-reload|reload)
+	restart
+	;;
+  condrestart)
+	[ -f /var/lock/subsys/supervisord ] && restart
+	;;
+  status)
+	status supervisord
+	RETVAL=$?
+	;;
+  *)
+	echo $"Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart}"
+	exit 1
+esac
+
+exit $RETVAL

--- a/etc/supervisor/conf.d/odin_server.conf
+++ b/etc/supervisor/conf.d/odin_server.conf
@@ -1,0 +1,3 @@
+[program:odin_server]
+command = odin_server --config=%(here)s/../../odin/testing/config/test.cfg
+    --static_path=%(here)s/../../odin/testing/static --debug_mode=1 --logging=info

--- a/etc/supervisor/supervisord.conf
+++ b/etc/supervisor/supervisord.conf
@@ -1,0 +1,32 @@
+; Example supervisord config file for odin_server
+
+[unix_http_server]
+file=/var/run/supervisor.sock   ; the path to the socket file
+chmod=0700                      ; socket file mode (default 0700)
+username=supervisor             ; default is no username (open server)
+password=123sup                 ; default is no password (open server)
+
+[supervisord]
+logfile=/var/log/supervisor/supervisord.log ; main log file;default $CWD/supervisord.log
+pidfile=/var/run/supervisord.pid            ; supervisord pidfile;default supervisord.pid
+childlogdir=/var/log/supervisor             ; 'AUTO' child log dir, default $TEMP
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+username=supervisor                   ; should be same as http_username if set
+password=123sup                       ; should be same as http_password if set
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = ./conf.d/*.conf

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyzmq>=15.2.0
 requests>=2.9.1
 tornado>=4.3
 future
+python-daemon>=2.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pyzmq>=15.2.0
 requests>=2.9.1
 tornado>=4.3
 future
-python-daemon>=2.1.2


### PR DESCRIPTION
Instead of dealing with the (complex) requirements of daemonising the odin server process programmatically, went instead with the wider recommendation to do this using supervisord. This can easily be installed either with pip or as a system package on most distros. Provided the appropriate configuration scripts as an example and copies of the Debian and RH (CentOS etc) init scripts in case of installation using pip.